### PR TITLE
Rename aggregated results to comply with readme

### DIFF
--- a/config/mercury_config.toml
+++ b/config/mercury_config.toml
@@ -103,7 +103,7 @@ insert_time_stamp = false
 save_all_hotspot_data = false
 hotspot_save_folder = "../results" # Save all regulation information
 
-file_aggregated_results = "results_test.csv"
+file_aggregated_results = "results.csv"
 
 skip_results = false # will skip computation of the results at the end. Good for testing quickly
 


### PR DESCRIPTION
In the readme we talk about results.csv as the final summarized object you get, however in the .toml file it's called results_test.csv