### PR TITLE
Bug crash due to ac_performances fuel flow calculation

### DIFF
--- a/config/mercury_config.toml
+++ b/config/mercury_config.toml
@@ -103,7 +103,7 @@ insert_time_stamp = false
 save_all_hotspot_data = false
 hotspot_save_folder = "../results" # Save all regulation information
 
-file_aggregated_results = "results_test.csv"
+file_aggregated_results = "results.csv"
 
 skip_results = false # will skip computation of the results at the end. Good for testing quickly
 

--- a/config/mercury_config.toml
+++ b/config/mercury_config.toml
@@ -103,7 +103,7 @@ insert_time_stamp = false
 save_all_hotspot_data = false
 hotspot_save_folder = "../results" # Save all regulation information
 
-file_aggregated_results = "results.csv"
+file_aggregated_results = "results_test.csv"
 
 skip_results = false # will skip computation of the results at the end. Good for testing quickly
 

--- a/libs/performance_models/openap/ac_perf/ac_performances.py
+++ b/libs/performance_models/openap/ac_perf/ac_performances.py
@@ -43,7 +43,7 @@ class AircraftPerformance(AircraftPerformanceGeneric):
 
         # mass should be in kg, tas in kt, alt in ft, path_angle in degree
         # Output from openAP is in kg/s
-        ff = 60*self.fuel.enroute(mass=mass, tas=v_tas, alt=fl, path_angle=bank)
+        ff = 60*self.fuel.enroute(mass=mass, tas=v_tas, alt=fl)
 
         return ff
 


### PR DESCRIPTION
Using OpenAP, changing ac_performances.py line 46 from:

    ff = 60*self.fuel.enroute(mass=mass, tas=v_tas, alt=fl, path_angle=bank)

to:

    ff = 60*self.fuel.enroute(mass=mass, tas=v_tas, alt=fl)

Gets rid of the error and the simulation actually completes. However, I don't know if we should expect a path_angle or not!