### PR TITLE
BADA3 to parquet generation scripts usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,7 @@ In the following command, replace ``BADA3_FILES_PATH`` with the location of the 
 
 .. code:: bash
 
+   cd input_generation_tools/
    python generate_bada3_input.py -s BADA3_FILES_PATH -d .
 
 Ensure you copy the generated parquet files into ``Mercury/libs/performance_models/bada3/data/``.

--- a/README.rst
+++ b/README.rst
@@ -150,8 +150,10 @@ In the following command, replace ``BADA3_FILES_PATH`` with the location of the 
 
 .. code:: bash
 
-   cd input_generation_tools/
-   python generate_bada3_input.py -s BADA3_FILES_PATH -d .
+   # Assuming that we are in the root folder of Mercury
+   cd input_generation_tools/ # The bada3 script is in the input_generation_tool/
+   mkdir -p ../libs/performance_models/bada3/data/ # Output folder must exist
+   python generate_bada3_input.py -s BADA3_FILES_PATH -d ../libs/performance_models/bada3/data/
 
 Ensure you copy the generated parquet files into ``Mercury/libs/performance_models/bada3/data/``.
 

--- a/input_generation_tools/generate_bada3_input.py
+++ b/input_generation_tools/generate_bada3_input.py
@@ -685,5 +685,5 @@ if __name__ == "__main__":
     ptf_ac_info.to_parquet(Path(output_folder) / 'ptf_ac_info.parquet')
     ptf_operations.to_parquet(Path(output_folder) / 'ptf_operations.parquet')
 
-    print('ALL DONE -- Ensure that BADA3 parquet files (now in ', output_folder,
-          'are stored for the scenarios into data/ac_performance/bada/bada3/ in your input folder')
+    print(f'ALL DONE -- Ensure that BADA3 parquet files (just delivered at {output_folder})'
+          f'Remember to set the mercury_config.toml at "performance_model" to "bada3" and have the parquet files at: Mercury/libs/performance_models/bada3/data/')


### PR DESCRIPTION
- Improved the documentation in the `README.rst` regarding the BADA3 to parquet files converter `generate_bada3_input.py`
- Improved printed "ALL DONE" message in the `generate_bada3_input.py`, reminding the user to change the `mercury_config.toml` to "bada3" in order to use the newly created bada3 parquet files.